### PR TITLE
Avoid to modify frozen String error in ruby 2.4

### DIFF
--- a/lib/rfd.rb
+++ b/lib/rfd.rb
@@ -512,7 +512,7 @@ module Rfd
     # Archive selected files and directories into a .zip file.
     def zip(zipfile_name)
       return unless zipfile_name
-      zipfile_name << '.zip' unless zipfile_name.end_with? '.zip'
+      zipfile_name += '.zip' unless zipfile_name.end_with? '.zip'
 
       Zip::File.open(zipfile_name, Zip::File::CREATE) do |zipfile|
         selected_items.each do |item|

--- a/lib/rfd/commands.rb
+++ b/lib/rfd/commands.rb
@@ -231,7 +231,8 @@ module Rfd
     # Number of times to repeat the next command.
     (?0..?9).each do |n|
       define_method(n) do
-        (@times ||= '') << n
+        @times ||= ''
+        @times += n
       end
     end
 

--- a/lib/rfd/item.rb
+++ b/lib/rfd/item.rb
@@ -84,9 +84,9 @@ module Rfd
     def mode
       @mode ||= begin
         m = stat.mode
-        ret = directory? ? 'd' : symlink? ? 'l' : '-'
-        [(m & 0700) / 64, (m & 070) / 8, m & 07].inject(ret) do |str, s|
-          str << "#{s & 4 == 4 ? 'r' : '-'}#{s & 2 == 2 ? 'w' : '-'}#{s & 1 == 1 ? 'x' : '-'}"
+        ft = directory? ? 'd' : symlink? ? 'l' : '-'
+        ret = [(m & 0700) / 64, (m & 070) / 8, m & 07].inject(ft) do |str, s|
+          str += "#{s & 4 == 4 ? 'r' : '-'}#{s & 2 == 2 ? 'w' : '-'}#{s & 1 == 1 ? 'x' : '-'}"
         end
         if m & 04000 != 0
           ret[3] = directory? ? 's' : 'S'

--- a/rfd.gemspec
+++ b/rfd.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'curses', '>= 1.0.0'
   spec.add_dependency 'rubyzip', '>= 1.0.0'
   spec.add_development_dependency "bundler", "~> 1.3"
-  spec.add_development_dependency "rake"
+  spec.add_development_dependency "rake", "< 11.0"
   spec.add_development_dependency 'rspec', "< 2.99"
 end


### PR DESCRIPTION
RuntimeError occurs when `bundle exec rake` in ruby 2.4 .

```
Failures:

  1) Rfd::Controller#spawn_panes
     Failure/Error: @rfd = Rfd.start tmpdir
     RuntimeError:
       can't modify frozen String

```