### PR TITLE
Configurable style for a file with cursor

### DIFF
--- a/bin/rfd
+++ b/bin/rfd
@@ -1,6 +1,22 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 require File.expand_path('../../lib/rfd', __FILE__)
+require 'optparse'
 
-rfd = Rfd.start ARGV[0] || '.'
+options = {}
+
+OptionParser.new do |opts|
+  opts.on "--current-style STYLE", /underline|reverse/, "Current file effect `underline` or `reverse`. Default is `underline`." do |style|
+    options[:current_style] = case style
+                              when 'reverse'
+                                Curses::A_REVERSE
+                              else
+                                Curses::A_UNDERLINE
+                              end
+  end
+
+  opts.parse! ARGV
+end
+
+rfd = Rfd.start(ARGV[0] || '.', options)
 rfd.run

--- a/lib/rfd.rb
+++ b/lib/rfd.rb
@@ -32,11 +32,11 @@ module Rfd
   #
   # ==== Parameters
   # * +dir+ - The initial directory.
-  def self.start(dir = '.')
+  def self.start(dir = '.', options)
     init_curses
     Rfd::Window.draw_borders
     Curses.stdscr.noutrefresh
-    rfd = Rfd::Controller.new
+    rfd = Rfd::Controller.new options
     rfd.cd dir
     Curses.doupdate
     rfd
@@ -48,8 +48,8 @@ module Rfd
     attr_reader :header_l, :header_r, :main, :command_line, :items, :displayed_items, :current_row, :current_page, :current_dir, :current_zip
 
     # :nodoc:
-    def initialize
-      @main = MainWindow.new
+    def initialize(options)
+      @main = MainWindow.new options[:current_style]
       @header_l = HeaderLeftWindow.new
       @header_r = HeaderRightWindow.new
       @command_line = CommandLineWindow.new

--- a/lib/rfd/windows.rb
+++ b/lib/rfd/windows.rb
@@ -81,8 +81,9 @@ module Rfd
     attr_reader :current_index, :begy
     attr_writer :number_of_panes
 
-    def initialize
+    def initialize(current_style = nil)
       @begy, @current_index, @number_of_panes = 5, 0, 2
+      @current_style = current_style || Curses::A_UNDERLINE
       super window: Curses::Pad.new(Curses.lines - 7, Curses.cols - 2)
     end
 
@@ -117,7 +118,7 @@ module Rfd
 
     def draw_item(item, current: false)
       setpos item.index % maxy, width * @current_index
-      attron(Curses.color_pair(item.color) | (current ? Curses::A_UNDERLINE : Curses::A_NORMAL)) do
+      attron(Curses.color_pair(item.color) | (current ? @current_style : Curses::A_NORMAL)) do
         self << item.to_s
       end
     end

--- a/spec/controller_spec.rb
+++ b/spec/controller_spec.rb
@@ -8,7 +8,7 @@ describe Rfd::Controller do
   around do |example|
     @stdout = capture(:stdout) do
       FileUtils.cp_r File.join(__dir__, 'testdir'), tmpdir
-      @rfd = Rfd.start tmpdir
+      @rfd = Rfd.start tmpdir, options
       def (@rfd.main).maxy
         3
       end
@@ -25,9 +25,24 @@ describe Rfd::Controller do
   end
 
   let(:tmpdir) { File.join __dir__, 'tmpdir' }
+  let(:options) { {} }
   let!(:controller) { @rfd }
   subject { controller }
   let(:items) { controller.items }
+
+  describe '#initialize' do
+    context 'When options has :current_style key' do
+      let(:options) { { current_style: Curses::A_REVERSE } }
+
+      subject { controller.main.instance_variable_get :@current_style }
+      it { should == Curses::A_REVERSE }
+    end
+
+    context 'When options has not :current_style key' do
+      subject { controller.main.instance_variable_get :@current_style }
+      it { should == Curses::A_UNDERLINE }
+    end
+  end
 
   describe '#spawn_panes' do
     before { controller.spawn_panes 3 }


### PR DESCRIPTION
There is no effect in a file with cursor in tmux. I try to resolve it with the command line arugment `--current-style` to custmize its effect.

## note

This problem reproduces below code in tmux. 
https://gist.github.com/ta1kt0me/d890ef0b25513be40e2e1e3b60d0d51a

Then my envrionment is 

- tmux 2.3
- mac OS 10.12.2
- ruby 2.4.0p0
- iTerm2 Build 3.0.13
